### PR TITLE
Refactor for use of VHDL Libraries

### DIFF
--- a/hardware/XilinxKcu1500/rtl/Hardware.vhd
+++ b/hardware/XilinxKcu1500/rtl/Hardware.vhd
@@ -28,12 +28,16 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
-use work.AxiStreamPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
+
+library lcls2_pgp_fw_lib; 
 
 entity Hardware is
    generic (
@@ -138,7 +142,7 @@ begin
    ---------------------
    -- AXI-Lite Crossbar
    ---------------------
-   U_XBAR : entity work.AxiLiteCrossbar
+   U_XBAR : entity surf.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
          NUM_SLAVE_SLOTS_G  => 1,
@@ -189,7 +193,7 @@ begin
    end generate GEN_REFCLK;
 
    GEN_PGP3_QPLL : if (PGP_TYPE_G = true) generate
-      U_QPLL : entity work.Pgp3GthUsQpll
+      U_QPLL : entity surf.Pgp3GthUsQpll
          generic map (
             TPD_G => TPD_G)
          port map (
@@ -211,7 +215,7 @@ begin
    for i in 3 downto 0 generate
 
       GEN_PGP3 : if (PGP_TYPE_G = true) generate
-         U_Lane : entity work.Kcu1500Pgp3Lane
+         U_Lane : entity lcls2_pgp_fw_lib.Kcu1500Pgp3Lane
             generic map (
                TPD_G                => TPD_G,
                ROGUE_SIM_EN_G       => ROGUE_SIM_EN_G,
@@ -247,7 +251,7 @@ begin
       end generate;
 
       GEN_PGP2b : if (PGP_TYPE_G = false) generate
-         U_Lane : entity work.Kcu1500Pgp2bLane
+         U_Lane : entity lcls2_pgp_fw_lib.Kcu1500Pgp2bLane
             generic map (
                TPD_G                => TPD_G,
                ROGUE_SIM_EN_G       => ROGUE_SIM_EN_G,
@@ -283,7 +287,7 @@ begin
    ------------------
    -- Timing Receiver
    ------------------
-   U_TimingRx : entity work.Kcu1500TimingRx
+   U_TimingRx : entity lcls2_pgp_fw_lib.Kcu1500TimingRx
       generic map (
          TPD_G             => TPD_G,
          SIMULATION_G      => ROGUE_SIM_EN_G,
@@ -314,7 +318,7 @@ begin
    --------------------
    -- Unused QSFP Links
    --------------------
-   U_QSFP1 : entity work.Gthe3ChannelDummy
+   U_QSFP1 : entity surf.Gthe3ChannelDummy
       generic map (
          TPD_G   => TPD_G,
          WIDTH_G => 2)

--- a/hardware/XilinxKcu1500/rtl/Kcu1500Pgp2bLane.vhd
+++ b/hardware/XilinxKcu1500/rtl/Kcu1500Pgp2bLane.vhd
@@ -16,13 +16,17 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
-use work.AxiStreamPkg.all;
-use work.Pgp2bPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.Pgp2bPkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
+
+library lcls2_pgp_fw_lib; 
 
 entity Kcu1500Pgp2bLane is
    generic (
@@ -90,7 +94,7 @@ architecture mapping of Kcu1500Pgp2bLane is
 
 begin
 
-   U_Trig : entity work.SynchronizerOneShot
+   U_Trig : entity surf.SynchronizerOneShot
       generic map (
          TPD_G => TPD_G)
       port map (
@@ -98,7 +102,7 @@ begin
          dataIn  => trigger,
          dataOut => locTxIn.opCodeEn);
 
-   U_Wtd : entity work.WatchDogRst
+   U_Wtd : entity surf.WatchDogRst
       generic map(
          TPD_G      => TPD_G,
          DURATION_G => getTimeRatio(AXIL_CLK_FREQ_G, 0.2))  -- 5 s timeout
@@ -107,7 +111,7 @@ begin
          monIn  => pgpRxOut.remLinkReady,
          rstOut => wdtRst);
 
-   U_PwrUpRst : entity work.PwrUpRst
+   U_PwrUpRst : entity surf.PwrUpRst
       generic map (
          TPD_G         => TPD_G,
          SIM_SPEEDUP_G => ROGUE_SIM_EN_G,
@@ -120,7 +124,7 @@ begin
    ---------------------
    -- AXI-Lite Crossbar
    ---------------------
-   U_XBAR : entity work.AxiLiteCrossbar
+   U_XBAR : entity surf.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
          NUM_SLAVE_SLOTS_G  => 1,
@@ -142,7 +146,7 @@ begin
    -- PGP Core
    -----------
    REAL_PGP : if (not ROGUE_SIM_EN_G) generate
-      U_Pgp : entity work.Pgp2bGthUltra
+      U_Pgp : entity surf.Pgp2bGthUltra
          generic map (
             TPD_G           => TPD_G,
             VC_INTERLEAVE_G => 1)       -- AxiStreamDmaV2 supports interleaving
@@ -214,7 +218,7 @@ begin
       pgpTxClk <= axilClk;
       pgpTxRst <= axilRst;
 
-      U_Rogue : entity work.RoguePgp2bSim
+      U_Rogue : entity surf.RoguePgp2bSim
          generic map(
             TPD_G      => TPD_G,
             PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
@@ -241,7 +245,7 @@ begin
    --------------         
    -- PGP Monitor
    --------------         
-   U_PgpMon : entity work.Pgp2bAxi
+   U_PgpMon : entity surf.Pgp2bAxi
       generic map (
          TPD_G              => TPD_G,
          COMMON_TX_CLK_G    => false,
@@ -274,7 +278,7 @@ begin
    -----------------------------
    -- Monitor the PGP TX streams
    -----------------------------
-   U_AXIS_TX_MON : entity work.AxiStreamMonAxiL
+   U_AXIS_TX_MON : entity surf.AxiStreamMonAxiL
       generic map(
          TPD_G            => TPD_G,
          COMMON_CLK_G     => false,
@@ -298,7 +302,7 @@ begin
    -----------------------------
    -- Monitor the PGP RX streams
    -----------------------------
-   U_AXIS_RX_MON : entity work.AxiStreamMonAxiL
+   U_AXIS_RX_MON : entity surf.AxiStreamMonAxiL
       generic map(
          TPD_G            => TPD_G,
          COMMON_CLK_G     => false,
@@ -322,7 +326,7 @@ begin
    --------------
    -- PGP TX Path
    --------------
-   U_Tx : entity work.PgpLaneTx
+   U_Tx : entity lcls2_pgp_fw_lib.PgpLaneTx
       generic map (
          TPD_G            => TPD_G,
          APP_AXI_CONFIG_G => DMA_AXIS_CONFIG_G,
@@ -344,7 +348,7 @@ begin
    --------------
    -- PGP RX Path
    --------------
-   U_Rx : entity work.PgpLaneRx
+   U_Rx : entity lcls2_pgp_fw_lib.PgpLaneRx
       generic map (
          TPD_G            => TPD_G,
          ROGUE_SIM_EN_G   => ROGUE_SIM_EN_G,

--- a/hardware/XilinxKcu1500/rtl/Kcu1500Pgp3Lane.vhd
+++ b/hardware/XilinxKcu1500/rtl/Kcu1500Pgp3Lane.vhd
@@ -16,10 +16,14 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
-use work.AxiStreamPkg.all;
-use work.Pgp3Pkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.Pgp3Pkg.all;
+
+library lcls2_pgp_fw_lib; 
 
 entity Kcu1500Pgp3Lane is
    generic (
@@ -84,7 +88,7 @@ architecture mapping of Kcu1500Pgp3Lane is
 
 begin
 
-   U_Trig : entity work.SynchronizerOneShot
+   U_Trig : entity surf.SynchronizerOneShot
       generic map (
          TPD_G => TPD_G)
       port map (
@@ -92,7 +96,7 @@ begin
          dataIn  => trigger,
          dataOut => pgpTxIn.opCodeEn);
 
-   U_Wtd : entity work.WatchDogRst
+   U_Wtd : entity surf.WatchDogRst
       generic map(
          TPD_G      => TPD_G,
          DURATION_G => getTimeRatio(AXIL_CLK_FREQ_G, 0.2))  -- 5 s timeout
@@ -101,7 +105,7 @@ begin
          monIn  => pgpRxOut.remRxLinkReady,
          rstOut => wdtRst);
 
-   U_PwrUpRst : entity work.PwrUpRst
+   U_PwrUpRst : entity surf.PwrUpRst
       generic map (
          TPD_G         => TPD_G,
          SIM_SPEEDUP_G => ROGUE_SIM_EN_G,
@@ -114,7 +118,7 @@ begin
    ---------------------
    -- AXI-Lite Crossbar
    ---------------------
-   U_XBAR : entity work.AxiLiteCrossbar
+   U_XBAR : entity surf.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
          NUM_SLAVE_SLOTS_G  => 1,
@@ -136,7 +140,7 @@ begin
    -- PGP Core
    -----------
    REAL_PGP : if (not ROGUE_SIM_EN_G) generate
-      U_Pgp : entity work.Pgp3GthUs
+      U_Pgp : entity surf.Pgp3GthUs
          generic map (
             TPD_G            => TPD_G,
             EN_PGP_MON_G     => true,
@@ -183,7 +187,7 @@ begin
 
    SIM_PGP : if (ROGUE_SIM_EN_G) generate
 
-      U_Rogue : entity work.RoguePgp3Sim
+      U_Rogue : entity surf.RoguePgp3Sim
          generic map(
             TPD_G      => TPD_G,
             PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
@@ -223,7 +227,7 @@ begin
    -----------------------------
    -- Monitor the PGP TX streams
    -----------------------------
-   U_AXIS_TX_MON : entity work.AxiStreamMonAxiL
+   U_AXIS_TX_MON : entity surf.AxiStreamMonAxiL
       generic map(
          TPD_G            => TPD_G,
          COMMON_CLK_G     => false,
@@ -247,7 +251,7 @@ begin
    -----------------------------
    -- Monitor the PGP RX streams
    -----------------------------
-   U_AXIS_RX_MON : entity work.AxiStreamMonAxiL
+   U_AXIS_RX_MON : entity surf.AxiStreamMonAxiL
       generic map(
          TPD_G            => TPD_G,
          COMMON_CLK_G     => false,
@@ -271,7 +275,7 @@ begin
    --------------
    -- PGP TX Path
    --------------
-   U_Tx : entity work.PgpLaneTx
+   U_Tx : entity lcls2_pgp_fw_lib.PgpLaneTx
       generic map (
          TPD_G            => TPD_G,
          APP_AXI_CONFIG_G => DMA_AXIS_CONFIG_G,
@@ -293,7 +297,7 @@ begin
    --------------
    -- PGP RX Path
    --------------
-   U_Rx : entity work.PgpLaneRx
+   U_Rx : entity lcls2_pgp_fw_lib.PgpLaneRx
       generic map (
          TPD_G            => TPD_G,
          ROGUE_SIM_EN_G   => ROGUE_SIM_EN_G,

--- a/hardware/XilinxKcu1500/rtl/Kcu1500TimingRx.vhd
+++ b/hardware/XilinxKcu1500/rtl/Kcu1500TimingRx.vhd
@@ -16,14 +16,20 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
-use work.AxiStreamPkg.all;
-use work.SsiPkg.all;
-use work.TimingPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+
+library lcls_timing_core;
+use lcls_timing_core.TimingPkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
+
+library lcls2_pgp_fw_lib; 
 
 entity Kcu1500TimingRx is
    generic (
@@ -159,7 +165,7 @@ begin
    -------------------------   
    -- Reference LCLS-I Clock
    -------------------------   
-   U_238MHz : entity work.ClockManagerUltraScale
+   U_238MHz : entity surf.ClockManagerUltraScale
       generic map(
          TPD_G              => TPD_G,
          SIMULATION_G       => SIMULATION_G,
@@ -188,7 +194,7 @@ begin
    --------------------------   
    -- Reference LCLS-II Clock
    --------------------------           
-   U_371MHz : entity work.ClockManagerUltraScale
+   U_371MHz : entity surf.ClockManagerUltraScale
       generic map(
          TPD_G              => TPD_G,
          SIMULATION_G       => SIMULATION_G,
@@ -217,7 +223,7 @@ begin
    -------------------------------------------------------
    -- Power Up Initialization of the KCU1500 Timing RX PHY
    -------------------------------------------------------
-   U_TimingPhyInit : entity work.TimingPhyInit
+   U_TimingPhyInit : entity lcls2_pgp_fw_lib.TimingPhyInit
       generic map (
          TPD_G              => TPD_G,
          SIMULATION_G       => SIMULATION_G,
@@ -236,7 +242,7 @@ begin
    ---------------------
    -- AXI-Lite Crossbar
    ---------------------
-   U_XBAR : entity work.AxiLiteCrossbar
+   U_XBAR : entity surf.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
          NUM_SLAVE_SLOTS_G  => 2,
@@ -264,7 +270,7 @@ begin
    GEN_VEC : for i in 1 downto 0 generate
 
       REAL_PCIE : if (not SIMULATION_G) generate
-         U_GTH : entity work.TimingGtCoreWrapper
+         U_GTH : entity lcls_timing_core.TimingGtCoreWrapper
             generic map (
                TPD_G            => TPD_G,
                EXTREF_G         => false,
@@ -329,7 +335,7 @@ begin
             CLR => '0',
             O   => refClkDiv2(i));
 
-      U_refRstDiv2 : entity work.RstSync
+      U_refRstDiv2 : entity surf.RstSync
          generic map (
             TPD_G => TPD_G)
          port map (
@@ -415,7 +421,7 @@ begin
    --------------
    -- Timing Core
    --------------
-   U_TimingCore : entity work.TimingCore
+   U_TimingCore : entity lcls_timing_core.TimingCore
       generic map (
          TPD_G             => TPD_G,
          DEFAULT_CLK_SEL_G => '0',  -- '0': default LCLS-I, '1': default LCLS-II
@@ -451,7 +457,7 @@ begin
    ---------------------
    -- Timing PHY Monitor
    ---------------------
-   U_Monitor : entity work.TimingPhyMonitor
+   U_Monitor : entity lcls2_pgp_fw_lib.TimingPhyMonitor
       generic map (
          TPD_G           => TPD_G,
          SIMULATION_G    => SIMULATION_G,
@@ -484,7 +490,7 @@ begin
    ---------------------
    -- Timing PHY Monitor
    ---------------------         
-   U_Trig : entity work.EvrV2CoreTriggers
+   U_Trig : entity lcls_timing_core.EvrV2CoreTriggers
       generic map (
          TPD_G           => TPD_G,
          NCHANNELS_G     => 8,
@@ -527,7 +533,7 @@ begin
       appTrigMasters(i).tLast                 <= '1';  -- EOF
       appTrigMasters(i).tUser(SSI_SOF_C)      <= '1';  -- SOF
 
-      U_Trig_Info_Fifo : entity work.AxiStreamFifoV2
+      U_Trig_Info_Fifo : entity surf.AxiStreamFifoV2
          generic map (
             -- General Configurations
             TPD_G               => TPD_G,
@@ -556,7 +562,7 @@ begin
       ---------------------------------
       -- Resize the Outbound AXI Stream
       --------------------------------- 
-      U_TxResize : entity work.AxiStreamResize
+      U_TxResize : entity surf.AxiStreamResize
          generic map (
             -- General Configurations
             TPD_G               => TPD_G,

--- a/hardware/XilinxKcu1500/rtl/TimingPhyInit.vhd
+++ b/hardware/XilinxKcu1500/rtl/TimingPhyInit.vhd
@@ -16,8 +16,10 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
 
 entity TimingPhyInit is
    generic (
@@ -65,7 +67,7 @@ architecture rtl of TimingPhyInit is
 
 begin
 
-   U_AxiLiteMaster : entity work.AxiLiteMaster
+   U_AxiLiteMaster : entity surf.AxiLiteMaster
       generic map (
          TPD_G => TPD_G)
       port map (

--- a/hardware/XilinxKcu1500/rtl/TimingPhyMonitor.vhd
+++ b/hardware/XilinxKcu1500/rtl/TimingPhyMonitor.vhd
@@ -16,8 +16,10 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
 
 entity TimingPhyMonitor is
    generic (
@@ -103,7 +105,7 @@ begin
    GEN_TRIG_FREQ :
    for i in 3 downto 0 generate
 
-      U_remTrigFreq : entity work.SyncTrigRate
+      U_remTrigFreq : entity surf.SyncTrigRate
          generic map (
             TPD_G          => TPD_G,
             COMMON_CLK_G   => true,
@@ -118,7 +120,7 @@ begin
             locClk      => axilClk,
             refClk      => axilClk);
 
-      U_remTrigDropFreq : entity work.SyncTrigRate
+      U_remTrigDropFreq : entity surf.SyncTrigRate
          generic map (
             TPD_G          => TPD_G,
             COMMON_CLK_G   => true,
@@ -133,7 +135,7 @@ begin
             locClk      => axilClk,
             refClk      => axilClk);
 
-      U_locTrigFreq : entity work.SyncTrigRate
+      U_locTrigFreq : entity surf.SyncTrigRate
          generic map (
             TPD_G          => TPD_G,
             COMMON_CLK_G   => true,
@@ -148,7 +150,7 @@ begin
             locClk      => axilClk,
             refClk      => axilClk);
 
-      U_locTrigDropFreq : entity work.SyncTrigRate
+      U_locTrigDropFreq : entity surf.SyncTrigRate
          generic map (
             TPD_G          => TPD_G,
             COMMON_CLK_G   => true,
@@ -167,7 +169,7 @@ begin
 
    GEN_REFCLK_FREQ :
    for i in 1 downto 0 generate
-      U_refClk : entity work.SyncClockFreq
+      U_refClk : entity surf.SyncClockFreq
          generic map (
             TPD_G          => TPD_G,
             REF_CLK_FREQ_G => AXIL_CLK_FREQ_G,
@@ -182,7 +184,7 @@ begin
             refClk  => axilClk);
    end generate GEN_REFCLK_FREQ;
 
-   Sync_txRst : entity work.Synchronizer
+   Sync_txRst : entity surf.Synchronizer
       generic map (
          TPD_G => TPD_G)
       port map (
@@ -190,7 +192,7 @@ begin
          dataIn  => txRst,
          dataOut => txReset);
 
-   U_txClkFreq : entity work.SyncClockFreq
+   U_txClkFreq : entity surf.SyncClockFreq
       generic map (
          TPD_G          => TPD_G,
          REF_CLK_FREQ_G => AXIL_CLK_FREQ_G,
@@ -204,7 +206,7 @@ begin
          locClk  => axilClk,
          refClk  => axilClk);
 
-   Sync_rxRst : entity work.Synchronizer
+   Sync_rxRst : entity surf.Synchronizer
       generic map (
          TPD_G => TPD_G)
       port map (
@@ -212,7 +214,7 @@ begin
          dataIn  => rxRst,
          dataOut => rxReset);
 
-   U_rxClkFreq : entity work.SyncClockFreq
+   U_rxClkFreq : entity surf.SyncClockFreq
       generic map (
          TPD_G          => TPD_G,
          REF_CLK_FREQ_G => AXIL_CLK_FREQ_G,
@@ -358,7 +360,7 @@ begin
       end if;
    end process seq;
 
-   U_mmcmRst : entity work.PwrUpRst
+   U_mmcmRst : entity surf.PwrUpRst
       generic map (
          TPD_G         => TPD_G,
          SIM_SPEEDUP_G => SIMULATION_G,
@@ -368,7 +370,7 @@ begin
          clk    => axilClk,
          rstOut => mmcmRst);
 
-   U_rxUserRst : entity work.PwrUpRst
+   U_rxUserRst : entity surf.PwrUpRst
       generic map (
          TPD_G         => TPD_G,
          SIM_SPEEDUP_G => SIMULATION_G,
@@ -378,7 +380,7 @@ begin
          clk    => axilClk,
          rstOut => rxUserRst);
 
-   U_txUserRst : entity work.PwrUpRst
+   U_txUserRst : entity surf.PwrUpRst
       generic map (
          TPD_G         => TPD_G,
          SIM_SPEEDUP_G => SIMULATION_G,

--- a/hardware/XilinxKcu1500/ruckus.tcl
+++ b/hardware/XilinxKcu1500/ruckus.tcl
@@ -2,7 +2,7 @@
 source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Load local source Code 
-loadSource      -dir  "$::DIR_PATH/rtl"
+loadSource      -lib lcls2_pgp_fw_lib -dir  "$::DIR_PATH/rtl"
 loadConstraints -path "$::DIR_PATH/xdc/Hardware.xdc"
 
 # Case the timing on communication protocol

--- a/shared/rtl/PgpLaneRx.vhd
+++ b/shared/rtl/PgpLaneRx.vhd
@@ -16,9 +16,11 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.StdRtlPkg.all;
-use work.AxiStreamPkg.all;
-use work.Pgp3Pkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.Pgp3Pkg.all;
 
 entity PgpLaneRx is
    generic (
@@ -65,7 +67,7 @@ begin
    GEN_VEC :
    for i in 3 downto 0 generate
 
-      BUFFER_FIFO : entity work.AxiStreamFifoV2
+      BUFFER_FIFO : entity surf.AxiStreamFifoV2
          generic map (
             -- General Configurations
             TPD_G               => TPD_G,
@@ -92,7 +94,7 @@ begin
             mAxisMaster => rxMasters(i),
             mAxisSlave  => rxSlaves(i));
 
-      BURST_RESIZE_FIFO : entity work.AxiStreamFifoV2
+      BURST_RESIZE_FIFO : entity surf.AxiStreamFifoV2
          generic map (
             -- General Configurations
             TPD_G               => TPD_G,

--- a/shared/rtl/PgpLaneTx.vhd
+++ b/shared/rtl/PgpLaneTx.vhd
@@ -16,8 +16,10 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.StdRtlPkg.all;
-use work.AxiStreamPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
 
 entity PgpLaneTx is
    generic (
@@ -57,7 +59,7 @@ begin
 
    linkReady <= txlinkReady and rxlinkReady;
 
-   U_FlushSync : entity work.Synchronizer
+   U_FlushSync : entity surf.Synchronizer
       generic map (
          TPD_G          => TPD_G,
          OUT_POLARITY_G => '0')
@@ -67,7 +69,7 @@ begin
          dataIn  => linkReady,
          dataOut => flushEn);
 
-   U_Flush : entity work.AxiStreamFlush
+   U_Flush : entity surf.AxiStreamFlush
       generic map (
          TPD_G         => TPD_G,
          AXIS_CONFIG_G => APP_AXI_CONFIG_G,
@@ -81,7 +83,7 @@ begin
          mAxisMaster => master,
          mAxisCtrl   => ctrl);
 
-   U_RESIZE : entity work.AxiStreamFifoV2
+   U_RESIZE : entity surf.AxiStreamFifoV2
       generic map (
          -- General Configurations
          TPD_G               => TPD_G,
@@ -109,7 +111,7 @@ begin
          mAxisMaster => txMaster,
          mAxisSlave  => txSlave);
 
-   U_SOF : entity work.SsiInsertSof
+   U_SOF : entity surf.SsiInsertSof
       generic map (
          TPD_G               => TPD_G,
          COMMON_CLK_G        => true,
@@ -129,7 +131,7 @@ begin
          mAxisMaster => txMasterSof,
          mAxisSlave  => txSlaveSof);
 
-   U_DeMux : entity work.AxiStreamDeMux
+   U_DeMux : entity surf.AxiStreamDeMux
       generic map (
          TPD_G         => TPD_G,
          NUM_MASTERS_G => 4,

--- a/shared/ruckus.tcl
+++ b/shared/ruckus.tcl
@@ -20,4 +20,4 @@ if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMO
 }
 
 # Load local source Code 
-loadSource -dir "$::DIR_PATH/rtl"
+loadSource -lib lcls2_pgp_fw_lib -dir "$::DIR_PATH/rtl"


### PR DESCRIPTION
This change refactors the code to expect [SURF](https://github.com/slaclab/surf) and  modules and packages to be in a `surf` VHDL library.

It also refactors the code to place it's own modules and packages in a `lcls2_pgp_fw_lib` library.

This PR can't be merged until the corresponding changes in `surf` are merged.
 - https://github.com/slaclab/surf/pull/541