### PR TITLE
Refactor for new MEMORY_TYPE_G generic in SURF

### DIFF
--- a/shared/rtl/PgpLaneRx.vhd
+++ b/shared/rtl/PgpLaneRx.vhd
@@ -73,7 +73,7 @@ begin
             TPD_G               => TPD_G,
             SLAVE_READY_EN_G    => ROGUE_SIM_EN_G,
             -- FIFO configurations
-            BRAM_EN_G           => true,
+            MEMORY_TYPE_G       => "block",
             GEN_SYNC_FIFO_G     => false,
             FIFO_ADDR_WIDTH_G   => 9,
             FIFO_FIXED_THRESH_G => true,
@@ -102,7 +102,7 @@ begin
             VALID_THOLD_G       => 128,  -- Hold until enough to burst into the interleaving MUX
             VALID_BURST_MODE_G  => true,
             -- FIFO configurations
-            BRAM_EN_G           => true,
+            MEMORY_TYPE_G       => "block",
             GEN_SYNC_FIFO_G     => true,
             FIFO_ADDR_WIDTH_G   => 9,
             -- AXI Stream Port Configurations

--- a/shared/rtl/PgpLaneTx.vhd
+++ b/shared/rtl/PgpLaneTx.vhd
@@ -92,7 +92,7 @@ begin
          SLAVE_READY_EN_G    => false,
          VALID_THOLD_G       => 1,
          -- FIFO configurations
-         BRAM_EN_G           => true,
+         MEMORY_TYPE_G       => "block",
          GEN_SYNC_FIFO_G     => false,
          FIFO_ADDR_WIDTH_G   => 5,
          FIFO_PAUSE_THRESH_G => 20,


### PR DESCRIPTION
Memory modules in SURF now use the `MEMORY_TYPE_G` generic instead of `BRAM_EN_G`. The code has been updated to reflect this.