### PR TITLE
Send Trigger Tags

### DIFF
--- a/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Hsio.vhd
+++ b/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Hsio.vhd
@@ -174,6 +174,7 @@ architecture mapping of SlacPgpCardG4Hsio is
    signal iTriggerData       : TriggerEventDataArray(NUM_PGP_LANES_G-1 downto 0);
    signal remoteTriggersComb : slv(NUM_PGP_LANES_G-1 downto 0);
    signal remoteTriggers     : slv(NUM_PGP_LANES_G-1 downto 0);
+   signal triggerCodes       : slv8Array(NUM_PGP_LANES_G-1 downto 0);
 
 begin
 
@@ -255,6 +256,7 @@ begin
                port map (
                   -- Trigger Interface
                   trigger         => remoteTriggers(i),
+                  triggerCode     => triggerCodes(i),
                   -- QPLL Interface
                   qpllLock        => qpllLock(i),
                   qpllClk         => qpllClk(i),
@@ -291,6 +293,7 @@ begin
                port map (
                   -- Trigger Interface
                   trigger         => remoteTriggers(i),
+                  triggerCode     => triggerCodes(i),
                   -- PGP Serial Ports
                   pgpRxP          => qsfp0RxP(i),
                   pgpRxN          => qsfp0RxN(i),
@@ -431,6 +434,7 @@ begin
    -- Feed triggers directly to PGP
    TRIGGER_GEN : for i in NUM_PGP_LANES_G-1 downto 0 generate
       remoteTriggersComb(i) <= iTriggerData(i).valid and iTriggerData(i).l0Accept;
+      trigerCodes(i)        <= "000" & iTriggerData(i).l0Tag;
    end generate TRIGGER_GEN;
    U_RegisterVector_1 : entity surf.RegisterVector
       generic map (

--- a/hardware/XilinxKcu1500/rtl/Kcu1500Hsio.vhd
+++ b/hardware/XilinxKcu1500/rtl/Kcu1500Hsio.vhd
@@ -159,6 +159,7 @@ architecture mapping of Kcu1500Hsio is
    signal iTriggerData       : TriggerEventDataArray(NUM_PGP_LANES_G-1 downto 0);
    signal remoteTriggersComb : slv(NUM_PGP_LANES_G-1 downto 0);
    signal remoteTriggers     : slv(NUM_PGP_LANES_G-1 downto 0);
+   signal triggerCodes       : slv8Array(NUM_PGP_LANES_G-1 downto 0);
 
    attribute dont_touch              : string;
    attribute dont_touch of refClk    : signal is "TRUE";
@@ -255,30 +256,30 @@ begin
                AXI_BASE_ADDR_G      => AXIL_CONFIG_C(i).baseAddr)
             port map (
                -- Trigger Interface
-               trigger                 => remoteTriggers(i),
-               triggerCode(4 downto 0) => iTriggerData(i).l0Tag,
+               trigger         => remoteTriggers(i),
+               triggerCode     => triggerCodes(i),
                -- QPLL Interface
-               qpllLock                => qpllLock(i),
-               qpllClk                 => qpllClk(i),
-               qpllRefclk              => qpllRefclk(i),
-               qpllRst                 => qpllRst(i),
+               qpllLock        => qpllLock(i),
+               qpllClk         => qpllClk(i),
+               qpllRefclk      => qpllRefclk(i),
+               qpllRst         => qpllRst(i),
                -- PGP Serial Ports
-               pgpRxP                  => qsfp0RxP(i),
-               pgpRxN                  => qsfp0RxN(i),
-               pgpTxP                  => qsfp0TxP(i),
-               pgpTxN                  => qsfp0TxN(i),
+               pgpRxP          => qsfp0RxP(i),
+               pgpRxN          => qsfp0RxN(i),
+               pgpTxP          => qsfp0TxP(i),
+               pgpTxN          => qsfp0TxN(i),
                -- Streaming Interface (axilClk domain)
-               pgpIbMaster             => pgpIbMasters(i),
-               pgpIbSlave              => pgpIbSlaves(i),
-               pgpObMasters            => pgpObMasters(i),
-               pgpObSlaves             => pgpObSlaves(i),
+               pgpIbMaster     => pgpIbMasters(i),
+               pgpIbSlave      => pgpIbSlaves(i),
+               pgpObMasters    => pgpObMasters(i),
+               pgpObSlaves     => pgpObSlaves(i),
                -- AXI-Lite Interface (axilClk domain)
-               axilClk                 => axilClk,
-               axilRst                 => axilRst,
-               axilReadMaster          => axilReadMasters(i),
-               axilReadSlave           => axilReadSlaves(i),
-               axilWriteMaster         => axilWriteMasters(i),
-               axilWriteSlave          => axilWriteSlaves(i));
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
       end generate;
 
       GEN_PGP2b : if (PGP_TYPE_G = "PGP2b") generate
@@ -292,26 +293,26 @@ begin
                AXI_BASE_ADDR_G      => AXIL_CONFIG_C(i).baseAddr)
             port map (
                -- Trigger Interface
-               trigger                 => remoteTriggers(i),
-               triggerCode(4 downto 0) => iTriggerData(i).l0Tag,
+               trigger         => remoteTriggers(i),
+               triggerCode     => triggerCodes(i),
                -- PGP Serial Ports
-               pgpRxP                  => qsfp0RxP(i),
-               pgpRxN                  => qsfp0RxN(i),
-               pgpTxP                  => qsfp0TxP(i),
-               pgpTxN                  => qsfp0TxN(i),
-               pgpRefClk               => refClk(0),
+               pgpRxP          => qsfp0RxP(i),
+               pgpRxN          => qsfp0RxN(i),
+               pgpTxP          => qsfp0TxP(i),
+               pgpTxN          => qsfp0TxN(i),
+               pgpRefClk       => refClk(0),
                -- Streaming Interface (axilClk domain)
-               pgpIbMaster             => pgpIbMasters(i),
-               pgpIbSlave              => pgpIbSlaves(i),
-               pgpObMasters            => pgpObMasters(i),
-               pgpObSlaves             => pgpObSlaves(i),
+               pgpIbMaster     => pgpIbMasters(i),
+               pgpIbSlave      => pgpIbSlaves(i),
+               pgpObMasters    => pgpObMasters(i),
+               pgpObSlaves     => pgpObSlaves(i),
                -- AXI-Lite Interface (axilClk domain)
-               axilClk                 => axilClk,
-               axilRst                 => axilRst,
-               axilReadMaster          => axilReadMasters(i),
-               axilReadSlave           => axilReadSlaves(i),
-               axilWriteMaster         => axilWriteMasters(i),
-               axilWriteSlave          => axilWriteSlaves(i));
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => axilReadMasters(i),
+               axilReadSlave   => axilReadSlaves(i),
+               axilWriteMaster => axilWriteMasters(i),
+               axilWriteSlave  => axilWriteSlaves(i));
       end generate;
 
    end generate GEN_LANE;
@@ -375,6 +376,7 @@ begin
    -- Feed l0 triggers directly to PGP
    TRIGGER_GEN : for i in NUM_PGP_LANES_G-1 downto 0 generate
       remoteTriggersComb(i) <= iTriggerData(i).valid and iTriggerData(i).l0Accept;
+      trigerCodes(i)        <= "000" & iTriggerData(i).l0Tag;
    end generate TRIGGER_GEN;
    U_RegisterVector_1 : entity surf.RegisterVector
       generic map (

--- a/hardware/XilinxKcu1500/rtl/Kcu1500Hsio.vhd
+++ b/hardware/XilinxKcu1500/rtl/Kcu1500Hsio.vhd
@@ -255,29 +255,30 @@ begin
                AXI_BASE_ADDR_G      => AXIL_CONFIG_C(i).baseAddr)
             port map (
                -- Trigger Interface
-               trigger         => remoteTriggers(i),
+               trigger                 => remoteTriggers(i),
+               triggerCode(4 downto 0) => iTriggerData(i).l0Tag,
                -- QPLL Interface
-               qpllLock        => qpllLock(i),
-               qpllClk         => qpllClk(i),
-               qpllRefclk      => qpllRefclk(i),
-               qpllRst         => qpllRst(i),
+               qpllLock                => qpllLock(i),
+               qpllClk                 => qpllClk(i),
+               qpllRefclk              => qpllRefclk(i),
+               qpllRst                 => qpllRst(i),
                -- PGP Serial Ports
-               pgpRxP          => qsfp0RxP(i),
-               pgpRxN          => qsfp0RxN(i),
-               pgpTxP          => qsfp0TxP(i),
-               pgpTxN          => qsfp0TxN(i),
+               pgpRxP                  => qsfp0RxP(i),
+               pgpRxN                  => qsfp0RxN(i),
+               pgpTxP                  => qsfp0TxP(i),
+               pgpTxN                  => qsfp0TxN(i),
                -- Streaming Interface (axilClk domain)
-               pgpIbMaster     => pgpIbMasters(i),
-               pgpIbSlave      => pgpIbSlaves(i),
-               pgpObMasters    => pgpObMasters(i),
-               pgpObSlaves     => pgpObSlaves(i),
+               pgpIbMaster             => pgpIbMasters(i),
+               pgpIbSlave              => pgpIbSlaves(i),
+               pgpObMasters            => pgpObMasters(i),
+               pgpObSlaves             => pgpObSlaves(i),
                -- AXI-Lite Interface (axilClk domain)
-               axilClk         => axilClk,
-               axilRst         => axilRst,
-               axilReadMaster  => axilReadMasters(i),
-               axilReadSlave   => axilReadSlaves(i),
-               axilWriteMaster => axilWriteMasters(i),
-               axilWriteSlave  => axilWriteSlaves(i));
+               axilClk                 => axilClk,
+               axilRst                 => axilRst,
+               axilReadMaster          => axilReadMasters(i),
+               axilReadSlave           => axilReadSlaves(i),
+               axilWriteMaster         => axilWriteMasters(i),
+               axilWriteSlave          => axilWriteSlaves(i));
       end generate;
 
       GEN_PGP2b : if (PGP_TYPE_G = "PGP2b") generate
@@ -291,25 +292,26 @@ begin
                AXI_BASE_ADDR_G      => AXIL_CONFIG_C(i).baseAddr)
             port map (
                -- Trigger Interface
-               trigger         => remoteTriggers(i),
+               trigger                 => remoteTriggers(i),
+               triggerCode(4 downto 0) => iTriggerData(i).l0Tag,
                -- PGP Serial Ports
-               pgpRxP          => qsfp0RxP(i),
-               pgpRxN          => qsfp0RxN(i),
-               pgpTxP          => qsfp0TxP(i),
-               pgpTxN          => qsfp0TxN(i),
-               pgpRefClk       => refClk(0),
+               pgpRxP                  => qsfp0RxP(i),
+               pgpRxN                  => qsfp0RxN(i),
+               pgpTxP                  => qsfp0TxP(i),
+               pgpTxN                  => qsfp0TxN(i),
+               pgpRefClk               => refClk(0),
                -- Streaming Interface (axilClk domain)
-               pgpIbMaster     => pgpIbMasters(i),
-               pgpIbSlave      => pgpIbSlaves(i),
-               pgpObMasters    => pgpObMasters(i),
-               pgpObSlaves     => pgpObSlaves(i),
+               pgpIbMaster             => pgpIbMasters(i),
+               pgpIbSlave              => pgpIbSlaves(i),
+               pgpObMasters            => pgpObMasters(i),
+               pgpObSlaves             => pgpObSlaves(i),
                -- AXI-Lite Interface (axilClk domain)
-               axilClk         => axilClk,
-               axilRst         => axilRst,
-               axilReadMaster  => axilReadMasters(i),
-               axilReadSlave   => axilReadSlaves(i),
-               axilWriteMaster => axilWriteMasters(i),
-               axilWriteSlave  => axilWriteSlaves(i));
+               axilClk                 => axilClk,
+               axilRst                 => axilRst,
+               axilReadMaster          => axilReadMasters(i),
+               axilReadSlave           => axilReadSlaves(i),
+               axilWriteMaster         => axilWriteMasters(i),
+               axilWriteSlave          => axilWriteSlaves(i));
       end generate;
 
    end generate GEN_LANE;

--- a/shared/rtl/Pgp2bLane.vhd
+++ b/shared/rtl/Pgp2bLane.vhd
@@ -38,6 +38,7 @@ entity Pgp2bLane is
    port (
       -- Trigger Interface
       trigger         : in  sl;
+      triggerCode     : in  slv(7 downto 0) := (others => '0');
       -- PGP Serial Ports
       pgpTxP          : out sl;
       pgpTxN          : out sl;
@@ -100,6 +101,14 @@ begin
          clk     => pgpTxClk,
          dataIn  => trigger,
          dataOut => locTxIn.opCodeEn);
+   
+   U_TrigCode : entity surf.Synchronizer
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk     => pgpTxClk,
+         dataIn  => triggerCode,
+         dataOut => locTxIn.opCode);
 
    U_Wtd : entity surf.WatchDogRst
       generic map(

--- a/shared/rtl/Pgp2bLane.vhd
+++ b/shared/rtl/Pgp2bLane.vhd
@@ -101,10 +101,11 @@ begin
          clk     => pgpTxClk,
          dataIn  => trigger,
          dataOut => locTxIn.opCodeEn);
-   
-   U_TrigCode : entity surf.Synchronizer
+
+   U_TrigCode : entity surf.SynchronizerVector
       generic map (
-         TPD_G => TPD_G)
+         TPD_G   => TPD_G,
+         WIDTH_G => 8)
       port map (
          clk     => pgpTxClk,
          dataIn  => triggerCode,

--- a/shared/rtl/Pgp3Lane.vhd
+++ b/shared/rtl/Pgp3Lane.vhd
@@ -97,9 +97,10 @@ begin
          dataIn  => trigger,
          dataOut => pgpTxIn.opCodeEn);
 
-   U_TrigCode : entity surf.Synchronizer
+   U_TrigCode : entity surf.SynchronizerVector
       generic map (
-         TPD_G => TPD_G)
+         TPD_G => TPD_G,
+         WIDTH_G => 8)
       port map (
          clk     => pgpClk,
          dataIn  => triggerCode,

--- a/shared/rtl/Pgp3Lane.vhd
+++ b/shared/rtl/Pgp3Lane.vhd
@@ -23,7 +23,7 @@ use surf.AxiLitePkg.all;
 use surf.AxiStreamPkg.all;
 use surf.Pgp3Pkg.all;
 
-library lcls2_pgp_fw_lib; 
+library lcls2_pgp_fw_lib;
 
 entity Pgp3Lane is
    generic (
@@ -36,6 +36,7 @@ entity Pgp3Lane is
    port (
       -- Trigger Interface
       trigger         : in  sl;
+      triggerCode     : in  slv(7 downto 0);
       -- QPLL Interface
       qpllLock        : in  slv(1 downto 0);
       qpllClk         : in  slv(1 downto 0);
@@ -95,6 +96,14 @@ begin
          clk     => pgpClk,
          dataIn  => trigger,
          dataOut => pgpTxIn.opCodeEn);
+
+   U_TrigCode : entity surf.Synchronizer
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk     => pgpClk,
+         dataIn  => triggerCode,
+         dataOut => pgpTxIn.opCodeData(7 downto 0));
 
    U_Wtd : entity surf.WatchDogRst
       generic map(


### PR DESCRIPTION
This change uses the PGP opCode bus to send a "Trigger Tag" down to the Front End. This tag  can then be appended to the data stream so that data frames can be matches with their trigger metadata. Uses the `l0Tag` field as the Trigger Tag.