### PR TITLE
Set DEFAULT_CLK_SEL_G = LCSI-I if EN_LCLS_I_TIMING_G=true

### DIFF
--- a/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4TimingRx.vhd
+++ b/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4TimingRx.vhd
@@ -441,7 +441,8 @@ begin
    U_TimingCore : entity lcls_timing_core.TimingCore
       generic map (
          TPD_G             => TPD_G,
-         DEFAULT_CLK_SEL_G => toSl(EN_LCLS_II_TIMING_G),  -- '0': default LCLS-I, '1': default LCLS-II
+         -- DEFAULT_CLK_SEL_G => toSl(EN_LCLS_II_TIMING_G),  -- '0': default LCLS-I, '1': default LCLS-II
+         DEFAULT_CLK_SEL_G => ite(EN_LCLS_I_TIMING_G, '0', '1'),  -- '0': default LCLS-I, '1': default LCLS-II
          TPGEN_G           => false,
          AXIL_RINGB_G      => false,
          ASYNC_G           => true,

--- a/hardware/XilinxKcu1500/rtl/Kcu1500TimingRx.vhd
+++ b/hardware/XilinxKcu1500/rtl/Kcu1500TimingRx.vhd
@@ -470,7 +470,8 @@ begin
    U_TimingCore : entity lcls_timing_core.TimingCore
       generic map (
          TPD_G             => TPD_G,
-         DEFAULT_CLK_SEL_G => toSl(EN_LCLS_II_TIMING_G),  -- '0': default LCLS-I, '1': default LCLS-II
+         -- DEFAULT_CLK_SEL_G => toSl(EN_LCLS_II_TIMING_G),  -- '0': default LCLS-I, '1': default LCLS-II
+         DEFAULT_CLK_SEL_G => ite(EN_LCLS_I_TIMING_G, '0', '1'),  -- '0': default LCLS-I, '1': default LCLS-II
          TPGEN_G           => false,
          AXIL_RINGB_G      => false,
          ASYNC_G           => true,


### PR DESCRIPTION
### Description
- Work around for Bruce Hill until [ESLTIMING-25](https://jira.slac.stanford.edu/browse/ESLTIMING-25) is fixed
- DEFAULT_CLK_SEL_G is stil LCSI-II for `timetool` with this update